### PR TITLE
fix(k8s): rm useless configmap

### DIFF
--- a/.k8s/environments/dev/app.configmap.yaml
+++ b/.k8s/environments/dev/app.configmap.yaml
@@ -5,5 +5,3 @@ metadata:
 data:
   NODE_ENV: "production"
   PORT: "3000"
-  NEXT_PUBLIC_MATOMO_URL: "https://matomo.fabrique.social.gouv.fr/"
-  NEXT_PUBLIC_MATOMO_SITE_ID: "33"

--- a/.k8s/environments/preprod/app.configmap.yaml
+++ b/.k8s/environments/preprod/app.configmap.yaml
@@ -5,5 +5,3 @@ metadata:
 data:
   NODE_ENV: "production"
   PORT: "3000"
-  NEXT_PUBLIC_MATOMO_URL: "https://matomo.fabrique.social.gouv.fr/"
-  NEXT_PUBLIC_MATOMO_SITE_ID: "33"

--- a/.k8s/environments/prod/app.configmap.yaml
+++ b/.k8s/environments/prod/app.configmap.yaml
@@ -5,5 +5,3 @@ metadata:
 data:
   NODE_ENV: "production"
   PORT: "3000"
-  NEXT_PUBLIC_MATOMO_URL: "https://matomo.fabrique.social.gouv.fr/"
-  NEXT_PUBLIC_MATOMO_SITE_ID: "33"


### PR DESCRIPTION
These variables are only needed at build-time for static sites. so they must be defined in gitlab-ci variables